### PR TITLE
fix(rituals): API V2 Support

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1305,8 +1305,8 @@ build.json @home-assistant/supervisor
 /tests/components/ring/ @sdb9696
 /homeassistant/components/risco/ @OnFreund
 /tests/components/risco/ @OnFreund
-/homeassistant/components/rituals_perfume_genie/ @milanmeu @frenck
-/tests/components/rituals_perfume_genie/ @milanmeu @frenck
+/homeassistant/components/rituals_perfume_genie/ @milanmeu @frenck @quebulm
+/tests/components/rituals_perfume_genie/ @milanmeu @frenck @quebulm
 /homeassistant/components/rmvtransport/ @cgtobi
 /tests/components/rmvtransport/ @cgtobi
 /homeassistant/components/roborock/ @Lash-L @allenporter

--- a/homeassistant/components/rituals_perfume_genie/config_flow.py
+++ b/homeassistant/components/rituals_perfume_genie/config_flow.py
@@ -6,14 +6,16 @@ import logging
 from typing import Any
 
 from aiohttp import ClientResponseError
-from pyrituals import Account, AuthenticationException
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant import config_entries
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import ACCOUNT_HASH, DOMAIN
+from .const import DOMAIN, USERNAME, PASSWORD, ACCOUNT_HASH
+from pyrituals import Account, AuthenticationException
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,14 +27,15 @@ DATA_SCHEMA = vol.Schema(
 )
 
 
-class RitualsPerfumeGenieConfigFlow(ConfigFlow, domain=DOMAIN):
+# Subclass of HA ConfigFlow + version bump for V2
+class RitualsPerfumeGenieConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Rituals Perfume Genie."""
 
-    VERSION = 1
+    VERSION = 2
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
+    ) -> FlowResult:
         """Handle the initial step."""
         if user_input is None:
             return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA)
@@ -56,11 +59,61 @@ class RitualsPerfumeGenieConfigFlow(ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(account.email)
             self._abort_if_unique_id_configured()
 
+            # In V2 we store email + password instead of account_hash
             return self.async_create_entry(
                 title=account.email,
-                data={ACCOUNT_HASH: account.account_hash},
+                data={USERNAME: user_input[CONF_EMAIL], PASSWORD: user_input[CONF_PASSWORD]},
             )
 
         return self.async_show_form(
             step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )
+
+    # Simple reauth flow to retrieve credentials again (V2)
+    async def async_step_reauth(self, data: dict[str, Any]) -> FlowResult:
+        """Reauth step: request credentials again for V2 token."""
+        # Keep it simple and compatible with the existing flow
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        """Form to log in again (V2)."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="reauth_confirm",
+                data_schema=DATA_SCHEMA,
+            )
+
+        session = async_get_clientsession(self.hass)
+        account = Account(user_input[CONF_EMAIL], user_input[CONF_PASSWORD], session)
+
+        errors = {}
+        try:
+            await account.authenticate()
+        except ClientResponseError:
+            _LOGGER.exception("Unexpected response (reauth)")
+            errors["base"] = "cannot_connect"
+        except AuthenticationException:
+            errors["base"] = "invalid_auth"
+        except Exception:
+            _LOGGER.exception("Unexpected exception (reauth)")
+            errors["base"] = "unknown"
+        else:
+            # Find the entry with the same unique_id and update stored data
+            entries = self.hass.config_entries.async_entries(DOMAIN)
+            for entry in entries:
+                if entry.unique_id == account.email:
+                    new_data = dict(entry.data)
+                    new_data[USERNAME] = user_input[CONF_EMAIL]
+                    new_data[PASSWORD] = user_input[CONF_PASSWORD]
+                    new_data.pop(ACCOUNT_HASH, None)  # remove old field
+                    self.hass.config_entries.async_update_entry(entry, data=new_data)
+                    await self.hass.config_entries.async_reload(entry.entry_id)
+                    break
+
+            return self.async_abort(reason="reauth_success")
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=DATA_SCHEMA,
+            errors=errors,
         )

--- a/homeassistant/components/rituals_perfume_genie/const.py
+++ b/homeassistant/components/rituals_perfume_genie/const.py
@@ -4,7 +4,12 @@ from datetime import timedelta
 
 DOMAIN = "rituals_perfume_genie"
 
+# Alt (API V1)
 ACCOUNT_HASH = "account_hash"
+
+# Neu (API V2):
+USERNAME = "username"
+PASSWORD = "password"
 
 # The API provided by Rituals is currently rate limited to 30 requests
 # per hour per IP address. To avoid hitting this limit, the polling

--- a/homeassistant/components/rituals_perfume_genie/manifest.json
+++ b/homeassistant/components/rituals_perfume_genie/manifest.json
@@ -1,10 +1,10 @@
 {
   "domain": "rituals_perfume_genie",
   "name": "Rituals Perfume Genie",
-  "codeowners": ["@milanmeu", "@frenck"],
+  "codeowners": ["@milanmeu", "@frenck", "@quebulm"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/rituals_perfume_genie",
   "iot_class": "cloud_polling",
   "loggers": ["pyrituals"],
-  "requirements": ["pyrituals==0.0.6"]
+  "requirements": ["pyrituals==0.0.7"]
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
The Rituals Perfume Genie integration now requires username and password for authentication. 
Existing configurations that relied on the legacy `account_hash` will no longer work automatically. 
Users will be prompted to reauthenticate once after upgrading.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #125437 
- This PR is related to issue: #125437 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
This PR updates `pyrituals` 0.0.7.

- Upstream changes: https://github.com/milanmeu/pyrituals/pull/6

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr